### PR TITLE
Bugfix: GAのcsvデータ読み取り順番の修正

### DIFF
--- a/ga/ga.py
+++ b/ga/ga.py
@@ -26,9 +26,7 @@ class GA:
         self.max_val = max_val
         self.rate = rate
         self.cross_rate = cross_rate
-        # FIXME: 一旦デバッグのために10にする
-        self.num_generations = 10
-        # self.num_generations = 500
+        self.num_generations = 500
 
         self.target = target
         self.jl_main = jl_main
@@ -83,8 +81,6 @@ class GA:
         parents1 = np.zeros((self.population_size, 4))
         parents2 = np.zeros((self.population_size, 4))
         fitness = np.array(fitness)
-        print("---")
-        print(fitness)
         weights = calc_weights(fitness)
         for i in range(self.population_size):
             parents1[i] = population[np.random.choice(self.population_size, p=weights)]
@@ -172,10 +168,10 @@ class GA:
                     nu=population[i][1],
                     recentness=population[i][2],
                     friendship=population[i][3],
-                    steps=100,
+                    steps=20000,
                 )
                 self.histories[i] = run_model(params)
-                fitness[i] = self.fitness_function(self.tovec(self.histories[i], 10))
+                fitness[i] = self.fitness_function(self.tovec(self.histories[i], 1000))
 
             # 選択
             parents1, parents2 = self.selection(population, fitness)
@@ -201,8 +197,9 @@ class GA:
             if self.debug:
                 arg = np.argmax(fitness)
                 best_fitness = -1 * np.max(fitness)
+                best_params = population[arg]
                 metrics = self.tovec(self.histories[arg], 10)
-                message = f"Generation {generation}: Best fitness = {best_fitness}, 10 metrics = {metrics}"
+                message = f"Generation {generation}: Best fitness = {best_fitness}, Best params = {best_params}, 10Metrics = {metrics}"
                 logging.info(message)
 
         # 適応度の最小値，ターゲット，最適解，10個の指標を返す
@@ -230,6 +227,6 @@ def calc_weights(x: np.ndarray) -> np.ndarray:
     """
 
     x = x - np.mean(x)
-    weights = sigmoid(10, x)
+    weights = sigmoid(5, x)
     weights /= np.sum(weights)
     return weights

--- a/ga/main.py
+++ b/ga/main.py
@@ -44,16 +44,16 @@ def main():
         if len(row) < 10:
             raise ValueError("Invalid target data.")
         target = History2VecResult(
-            gamma=float(row[-10]),
-            no=float(row[-9]),
-            nc=float(row[-8]),
-            oo=float(row[-7]),
-            oc=float(row[-6]),
-            c=float(row[-5]),
-            y=float(row[-4]),
-            g=float(row[-3]),
-            r=float(row[-2]),
-            h=float(row[-1]),
+            gamma=float(row[0]),
+            c=float(row[1]),
+            oc=float(row[2]),
+            oo=float(row[3]),
+            nc=float(row[4]),
+            no=float(row[5]),
+            y=float(row[6]),
+            r=float(row[7]),
+            h=float(row[8]),
+            g=float(row[9]),
         )
 
         ga = GA(


### PR DESCRIPTION
## FIX

csvの読み取りの際のカラムの順番が間違っており，GAの学習がうまく進まなかった．この修正によって（少なくとも小さなデータセットでは）うまく学習が進むことが確認できた．

## [補足]確認方法

世代数10，個体数10，ターゲットデータaps，交叉率0.80，突然変異率0.01 でGAによる探索を行った．各世代ごとの10この個体の適応度の平均値をplotすると下図のようになった．

<img width="752" alt="Screenshot 2023-06-10 at 0 36 23" src="https://github.com/tsukuba-websci/MPS-TOM-Urnmodel/assets/86868255/a768f283-c457-4820-9361-96ece2deedda">

以前は，3~4の間で振動してしまっていたので，十分に修正されたと考えられる．

## [補足2] 重み付け

適合度を重みにうまく反映できるよう，重みの算出にシグモイド関数を使っている．シグモイド関数の係数aを5に設定しているが，これはここまで大きい必要は無さそうなので，もう少し小さくして様子を見たい（というかsoftmaxで良さそう...??）

 https://github.com/tsukuba-websci/MPS-TOM-Urnmodel/blob/f6c12f219b15fbbd8441c68e4ba4ce422bb53ded/ga/ga.py#L230